### PR TITLE
Chat-space 自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,6 +1,4 @@
 $(function(){
-  last_message_id = $('.main-chat__message-list__messages:last').data("message-id");
-  console.log(last_message_id);
 
     function buildHTML(message){
       if ( message.image ) {
@@ -64,5 +62,31 @@ $(function(){
       .fail(function(){
         alert('error');
       })  
-  })
+  });
+
+  var reloadMessages = function() {
+    last_message_id = $('.main-chat__message-list__messages:last').data("message-id");
+    $.ajax({
+      url: "api/messages",
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      if (messages.length !== 0) {
+        var insertHTML = ''
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+        });
+        $('.main-chat__message-list').append(insertHTML);
+        $('.main-chat__message-list').animate({ scrollTop: $('.main-chat__message-list')[0].scrollHeight});
+       }
+    })
+    .fail(function() {
+      alert('error');
+    });
+  };
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+  setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,4 +1,7 @@
 $(function(){
+  last_message_id = $('.main-chat__message-list__messages:last').data("message-id");
+  console.log(last_message_id);
+
     function buildHTML(message){
       if ( message.image ) {
         var html =

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/views/api/messages/create.json.jbuilder
+++ b/app/views/api/messages/create.json.jbuilder
@@ -1,0 +1,5 @@
+json.content    @message.content
+json.image      @message.image.url
+json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+json.user_name @message.user.name
+json.id @message.id

--- a/app/views/api/messages/create.json.jbuilder
+++ b/app/views/api/messages/create.json.jbuilder
@@ -1,5 +1,0 @@
-json.content    @message.content
-json.image      @message.image.url
-json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
-json.user_name @message.user.name
-json.id @message.id

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.main-chat__message-list__messages
+.main-chat__message-list__messages{data: {message: {id: message.id}}}
   .main-chat__message-list__messages__up
     %p.main-chat__message-list__messages__up__upuser
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.user_name @message.user.name
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.content @message.content
 json.image @message.image_url
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# What
あるユーザーが投稿したら、他のユーザーのブラウザにもリロードなしでそのメッセージが表示されるようにする

# Why
- メッセージIDの確認ができるようにするため
- 新規投稿を取得できているかの確認のため
- 投稿内容をレスポンスできるようにするため
- 数秒ごとにリクエストするため
- 必要ない場所では自動更新させないようにするため


## 2画面での自動更新の動き
https://gyazo.com/e641a6ca1cf4a2589567d8c6d747ac91